### PR TITLE
use `unsigned char` for `e_abstract_gamepad_button`

### DIFF
--- a/include/libmcc/input/input.h
+++ b/include/libmcc/input/input.h
@@ -28,7 +28,7 @@ namespace libmcc {
         _gamepad_button_y = 13,
     };
 
-    enum e_abstract_gamepad_button : char {
+    enum e_abstract_gamepad_button : unsigned char {
         _abstract_gamepad_button_left_trigger,
         _abstract_gamepad_button_right_trigger,
         _abstract_gamepad_button_up,


### PR DESCRIPTION
clang doesn't like it
```
dep\libmcc\include\libmcc\input\input.h(50,36): error : enumerator value evaluates to 255, which cannot be narrowed to type 'char' [-Wc++11-narrowing]
     50 |                 k_abstract_gamepad_button_none = 0xFF,
        |                                                  ^
```