### PR TITLE
update `s_general_video_settings` u64 field

### DIFF
--- a/include/libmcc/game/game_settings.h
+++ b/include/libmcc/game/game_settings.h
@@ -48,7 +48,8 @@ namespace libmcc {
     static_assert(sizeof(s_render_settings) == 184);
 
     struct s_general_video_settings {
-        uint64_t : 64;
+        int width;
+        int width;
         char texture_resolution;
         char texture_filtering_quality;
         char lighting_quality;


### PR DESCRIPTION
Required for halo 1 to boot slightly further.
```cpp
bool __fastcall libmcc::c_game_manager::get_video_setting(s_game_video_settings* settings) {
	if (settings) {
		memcpy(settings, &video_settings, sizeof(video_settings));
	}

	return true;
}
```
`settings` already has old width and height but by memcpying it, it gets set to 0 and crashes to due division by 0. it cant be set in function due to missing field which is fixed by this PR (or just return current settings.)
```cpp
bool __fastcall libmcc::c_game_manager::get_video_setting(s_game_video_settings* settings) {
	return true;
}
```